### PR TITLE
feat: Fuel consumption & distance travelled

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Built with rust and [ratatui](https://ratatui.rs/).
 | Vehicle speed (VSS)        | How fast car actually go                               | km/h    |
 | EL                         | Electric load                                          | ON/OFF  |
 | AC                         | AC switch                                              | ON/OFF  |
-| PSP                        | PSP switch                                             | ON/OFF  |
+| PSP                        | Power steering pump switch                             | ON/OFF  |
 | RAD                        | Radiator fan                                           | ON/OFF  |
 | Fuel cut                   | Deceleration fuel cut off (DFCO). Calc. from inj. pw   | ON/OFF  |
 

--- a/script.sh
+++ b/script.sh
@@ -3,11 +3,8 @@
 BINARY_PATH="/opt/suzui-rs/suzui-rs"
 
 while true; do
-    # Countdown from 5 to 1
-    for i in 5 4 3 2 1; do
-        clear
-        echo "Cycle Key IGN-ACC-IGN, Starting binary in $i seconds..."
-        sleep 1
-    done
     $BINARY_PATH
+    echo "Waiting 5 seconds before retrying"
+    sleep 5
+    clear
 done

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod sdl;
+pub mod strings;
 pub mod widgets;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod sdl;
 pub mod strings;
+pub mod toggle_detector;
 pub mod widgets;

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,9 +85,6 @@ impl App {
         }
         while self.running {
             self.sdl_viewer.update_raw_data(should_simulate);
-            self.sdl_viewer.update_processed_data();
-            terminal.draw(|frame| self.render(frame))?;
-            self.handle_crossterm_events(should_simulate)?;
 
             // Trip meter reset logic
             if self
@@ -97,11 +94,16 @@ impl App {
                 self.reset_trip_meter();
             }
 
+            self.sdl_viewer.update_processed_data();
+
             // Write to file
             if self.last_write.elapsed() > Duration::from_secs(15) {
                 self.persistence_write()?;
                 self.last_write = Instant::now();
             }
+
+            terminal.draw(|frame| self.render(frame))?;
+            self.handle_crossterm_events(should_simulate)?;
         }
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,10 @@ use clap::Parser;
 use std::time::{Duration, Instant};
 
 use color_eyre::Result;
-use crossterm::event::{self, poll, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, poll};
 use ratatui::{
-    layout::{Constraint, Direction, Layout},
     DefaultTerminal, Frame,
+    layout::{Constraint, Direction, Layout},
 };
 use suzui_rs::{
     sdl::SuzukiSdlViewer,

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,8 +96,8 @@ impl App {
                 Constraint::Length(7), // throttle
                 Constraint::Length(4), // load
                 Constraint::Length(3), // electrical
-                Constraint::Length(3), // vehicle
-                Constraint::Length(4), // flags
+                Constraint::Length(4), // vehicle
+                Constraint::Length(3), // flags
             ])
             .split(layout[1]);
 

--- a/src/sdl.rs
+++ b/src/sdl.rs
@@ -7,7 +7,7 @@ use std::{
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, FromRepr};
 
-use crate::strings::DISTANCE_FUEL_FILE_PATH;
+use crate::strings::{DISTANCE_FUEL_FILE_PATH, VAG_KKL_PORT};
 
 #[derive(Debug)]
 pub struct ScanToolParameterValue {
@@ -243,7 +243,7 @@ pub struct SuzukiSdlViewer {
 
 impl Default for SuzukiSdlViewer {
     fn default() -> Self {
-        let vag_kkl = serialport::new("/dev/ttyUSB0", 7812)
+        let vag_kkl = serialport::new(VAG_KKL_PORT, 7812)
             .timeout(Duration::from_secs(1))
             .open_native();
         let mut raw_data: HashMap<ObdAddress, u8> = HashMap::new();

--- a/src/sdl.rs
+++ b/src/sdl.rs
@@ -7,6 +7,8 @@ use std::{
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, FromRepr};
 
+use crate::strings::DISTANCE_FUEL_FILE_PATH;
+
 #[derive(Debug)]
 pub struct ScanToolParameterValue {
     pub value: f32,
@@ -246,11 +248,20 @@ impl Default for SuzukiSdlViewer {
         for obd_address in ObdAddress::iter() {
             raw_data.insert(obd_address, 0);
         }
+
+        // load up cumulative data from file if valid.
+        let mut engine_context = EngineContext::default();
+        let distance_fuel =
+            std::fs::read_to_string(DISTANCE_FUEL_FILE_PATH).unwrap_or("0.0,0.0".to_string());
+        let split: Vec<&str> = distance_fuel.split(",").collect();
+        engine_context.cumulative_distance = split[0].parse().unwrap_or(0.0);
+        engine_context.cumulative_fuel = split[1].parse().unwrap_or(0.0);
+
         Self {
             port: vag_kkl.ok(),
             ecu_id: None,
             raw_data,
-            engine_context: EngineContext::default(),
+            engine_context,
         }
     }
 }

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,5 +1,9 @@
+// you will LOL at the path but it's the simplest solution.
+// I've set root as read-only and instead of trying to setup a certain dir
+// as writeable, saving to `/boot` is easiest as that is on another
+// partition and is still writeable even if "ro" flag is set.
 #[cfg(target_arch = "aarch64")]
-pub const DISTANCE_FUEL_FILE_PATH: &str = "/home/dietpi/distance_fuel";
+pub const DISTANCE_FUEL_FILE_PATH: &str = "/boot/distance_fuel";
 
 #[cfg(not(target_arch = "aarch64"))]
 pub const DISTANCE_FUEL_FILE_PATH: &str = "/tmp/distance_fuel";

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,9 +1,5 @@
-// you will LOL at the path but it's the simplest solution.
-// I've set root as read-only and instead of trying to setup a certain dir
-// as writeable, saving to `/boot` is easiest as that is on another
-// partition and is still writeable even if "ro" flag is set.
 #[cfg(target_arch = "aarch64")]
-pub const DISTANCE_FUEL_FILE_PATH: &str = "/boot/firmware/distance_fuel";
+pub const DISTANCE_FUEL_FILE_PATH: &str = "/home/dietpi/distance_fuel";
 
 #[cfg(not(target_arch = "aarch64"))]
 pub const DISTANCE_FUEL_FILE_PATH: &str = "/tmp/distance_fuel";

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,0 +1,5 @@
+#[cfg(target_arch = "aarch64")]
+pub const DISTANCE_FUEL_FILE_PATH: &str = "/home/dietpi/distance_fuel";
+
+#[cfg(not(target_arch = "aarch64"))]
+pub const DISTANCE_FUEL_FILE_PATH: &str = "/tmp/distance_fuel";

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -7,3 +7,5 @@ pub const DISTANCE_FUEL_FILE_PATH: &str = "/boot/firmware/distance_fuel";
 
 #[cfg(not(target_arch = "aarch64"))]
 pub const DISTANCE_FUEL_FILE_PATH: &str = "/tmp/distance_fuel";
+
+pub const VAG_KKL_PORT: &str = "/dev/ttyUSB0";

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -3,7 +3,7 @@
 // as writeable, saving to `/boot` is easiest as that is on another
 // partition and is still writeable even if "ro" flag is set.
 #[cfg(target_arch = "aarch64")]
-pub const DISTANCE_FUEL_FILE_PATH: &str = "/boot/distance_fuel";
+pub const DISTANCE_FUEL_FILE_PATH: &str = "/boot/firmware/distance_fuel";
 
 #[cfg(not(target_arch = "aarch64"))]
 pub const DISTANCE_FUEL_FILE_PATH: &str = "/tmp/distance_fuel";

--- a/src/toggle_detector.rs
+++ b/src/toggle_detector.rs
@@ -1,0 +1,59 @@
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ToggleDetector {
+    last_state: bool,
+    toggle_count: u8,
+    first_toggle_time: Option<Instant>,
+    required_toggles: u8,
+    time_window: Duration,
+}
+
+impl ToggleDetector {
+    pub fn new() -> Self {
+        Self {
+            last_state: false,
+            toggle_count: 0,
+            first_toggle_time: None,
+            required_toggles: 6,
+            time_window: Duration::from_secs(8),
+        }
+    }
+
+    pub fn update(&mut self, current_el_state: bool) -> bool {
+        if current_el_state != self.last_state {
+            let now = Instant::now();
+
+            if self.first_toggle_time.is_none() {
+                self.first_toggle_time = Some(now);
+                self.toggle_count = 1;
+            } else if now.duration_since(self.first_toggle_time.unwrap()) <= self.time_window {
+                self.toggle_count += 1;
+
+                if self.toggle_count >= self.required_toggles {
+                    self.reset_detector();
+                    return true;
+                }
+            } else {
+                self.first_toggle_time = Some(now);
+                self.toggle_count = 1;
+            }
+        } else if let Some(first_time) = self.first_toggle_time {
+            if Instant::now().duration_since(first_time) > self.time_window {
+                self.reset_detector();
+            }
+        }
+        false
+    }
+
+    fn reset_detector(&mut self) {
+        self.toggle_count = 0;
+        self.first_toggle_time = None;
+    }
+}
+
+impl Default for ToggleDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/widgets/electrical.rs
+++ b/src/widgets/electrical.rs
@@ -44,7 +44,7 @@ impl Widget for ElectricalBlock {
             .split(area.inner(Margin::new(1, 0)));
         let battery_color = match self.rpm {
             rpm if rpm > 0 => match self.battery_voltage {
-                batt_volt if batt_volt < 13.1 || batt_volt > 15.2 => (Color::Red, Color::White),
+                batt_volt if !(13.1..=15.2).contains(&batt_volt) => (Color::Red, Color::White),
                 _ => (Color::Black, Color::Green),
             },
             _ => match self.battery_voltage {
@@ -52,7 +52,7 @@ impl Widget for ElectricalBlock {
                 batt_volt if batt_volt < 12.4 || (batt_volt > 12.8 && batt_volt <= 13.1) => {
                     (Color::Black, Color::LightYellow)
                 }
-                batt_volt if batt_volt >= 12.4 && batt_volt <= 12.8 => (Color::Black, Color::Green),
+                batt_volt if (12.4..=12.8).contains(&batt_volt) => (Color::Black, Color::Green),
                 _ => (Color::Black, Color::Red),
             },
         };

--- a/src/widgets/flags.rs
+++ b/src/widgets/flags.rs
@@ -60,20 +60,20 @@ impl Widget for FlagsBlock {
             .bg(if self.el { Color::Green } else { Color::Black })
             .centered()
             .bold()
-            .render(flags_layout_split[0].inner(Margin::new(1, 0)), buf);
+            .render(flags_layout_split[0], buf);
         Paragraph::new("A/C")
             .white()
             .bg(if self.ac { Color::Green } else { Color::Black })
             .bold()
             .centered()
-            .render(flags_layout_split[1].inner(Margin::new(1, 0)), buf);
+            .render(flags_layout_split[1], buf);
         Paragraph::new("PSP")
             .white()
             .bold()
             .bg(if self.psp { Color::Green } else { Color::Black })
             .centered()
-            .render(flags_layout_split[2].inner(Margin::new(1, 0)), buf);
-        Paragraph::new("RAD")
+            .render(flags_layout_split[2], buf);
+        Paragraph::new("R/F")
             .white()
             .bold()
             .bg(if self.rad_fan {
@@ -82,6 +82,6 @@ impl Widget for FlagsBlock {
                 Color::Black
             })
             .centered()
-            .render(flags_layout_split[3].inner(Margin::new(1, 0)), buf);
+            .render(flags_layout_split[3], buf);
     }
 }

--- a/src/widgets/flags.rs
+++ b/src/widgets/flags.rs
@@ -56,47 +56,31 @@ impl Widget for FlagsBlock {
             ])
             .split(flags_layout[1]);
         Paragraph::new("E/L")
-            .style(
-                Style::default()
-                    .fg(if self.el { Color::White } else { Color::White })
-                    .bg(if self.el { Color::Green } else { Color::Black })
-                    .bold(),
-            )
+            .white()
+            .bg(if self.el { Color::Green } else { Color::Black })
             .centered()
+            .bold()
             .render(flags_layout_split[0].inner(Margin::new(1, 0)), buf);
         Paragraph::new("A/C")
-            .style(
-                Style::default()
-                    .fg(if self.ac { Color::White } else { Color::White })
-                    .bg(if self.ac { Color::Green } else { Color::Black })
-                    .bold(),
-            )
+            .white()
+            .bg(if self.ac { Color::Green } else { Color::Black })
+            .bold()
             .centered()
             .render(flags_layout_split[1].inner(Margin::new(1, 0)), buf);
         Paragraph::new("PSP")
-            .style(
-                Style::default()
-                    .fg(if self.psp { Color::White } else { Color::White })
-                    .bg(if self.psp { Color::Green } else { Color::Black })
-                    .bold(),
-            )
+            .white()
+            .bold()
+            .bg(if self.psp { Color::Green } else { Color::Black })
             .centered()
             .render(flags_layout_split[2].inner(Margin::new(1, 0)), buf);
         Paragraph::new("RAD")
-            .style(
-                Style::default()
-                    .fg(if self.rad_fan {
-                        Color::White
-                    } else {
-                        Color::White
-                    })
-                    .bg(if self.rad_fan {
-                        Color::Green
-                    } else {
-                        Color::Black
-                    })
-                    .bold(),
-            )
+            .white()
+            .bold()
+            .bg(if self.rad_fan {
+                Color::Green
+            } else {
+                Color::Black
+            })
             .centered()
             .render(flags_layout_split[3].inner(Margin::new(1, 0)), buf);
     }

--- a/src/widgets/flags.rs
+++ b/src/widgets/flags.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders},
+    widgets::{Block, Borders, Paragraph},
 };
 
 use crate::sdl::EngineContext;
@@ -42,95 +42,62 @@ impl Widget for FlagsBlock {
             .direction(Direction::Vertical)
             .constraints(vec![
                 Constraint::Length(1),
-                Constraint::Percentage(100), // data
+                Constraint::Length(1), // data
                 Constraint::Length(1),
             ])
             .split(area.inner(Margin::new(1, 0)));
         let flags_layout_split = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints(vec![Constraint::Length(1), Constraint::Length(1)])
+            .direction(Direction::Horizontal)
+            .constraints(vec![
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+                Constraint::Percentage(25),
+            ])
             .split(flags_layout[1]);
-        let flags_layout_split_top = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints(vec![
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-            ])
-            .split(flags_layout_split[0]);
-        let flags_layout_split_bottom = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints(vec![
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-                Constraint::Percentage(25),
-            ])
-            .split(flags_layout_split[1]);
-        Span::styled(
-            "EL:",
-            Style::default()
-                .fg(if self.el { Color::Green } else { Color::White })
-                .add_modifier(Modifier::BOLD),
-        )
-        .render(flags_layout_split_top[0], buf);
-        Span::styled(
-            if self.el { "ON" } else { "OFF" },
-            Style::default()
-                .fg(if self.el { Color::Green } else { Color::White })
-                .add_modifier(Modifier::BOLD),
-        )
-        .render(flags_layout_split_top[1], buf);
-        Span::styled(
-            "AC:",
-            Style::default()
-                .fg(if self.ac { Color::Green } else { Color::White })
-                .add_modifier(Modifier::BOLD),
-        )
-        .render(flags_layout_split_top[2], buf);
-        Span::styled(
-            if self.ac { "ON" } else { "OFF" },
-            Style::default()
-                .fg(if self.ac { Color::Green } else { Color::White })
-                .add_modifier(Modifier::BOLD),
-        )
-        .render(flags_layout_split_top[3], buf);
-        Span::styled(
-            "PSP:",
-            Style::default()
-                .fg(if self.psp { Color::Green } else { Color::White })
-                .add_modifier(Modifier::BOLD),
-        )
-        .render(flags_layout_split_bottom[0], buf);
-        Span::styled(
-            if self.psp { "ON" } else { "OFF" },
-            Style::default()
-                .fg(if self.psp { Color::Green } else { Color::White })
-                .add_modifier(Modifier::BOLD),
-        )
-        .render(flags_layout_split_bottom[1], buf);
-        Span::styled(
-            "RAD:",
-            Style::default()
-                .fg(if self.rad_fan {
-                    Color::Green
-                } else {
-                    Color::White
-                })
-                .add_modifier(Modifier::BOLD),
-        )
-        .render(flags_layout_split_bottom[2], buf);
-        Span::styled(
-            if self.rad_fan { "ON" } else { "OFF" },
-            Style::default()
-                .fg(if self.rad_fan {
-                    Color::Green
-                } else {
-                    Color::White
-                })
-                .add_modifier(Modifier::BOLD),
-        )
-        .render(flags_layout_split_bottom[3], buf);
+        Paragraph::new("E/L")
+            .style(
+                Style::default()
+                    .fg(if self.el { Color::White } else { Color::White })
+                    .bg(if self.el { Color::Green } else { Color::Black })
+                    .bold(),
+            )
+            .centered()
+            .render(flags_layout_split[0].inner(Margin::new(1, 0)), buf);
+        Paragraph::new("A/C")
+            .style(
+                Style::default()
+                    .fg(if self.ac { Color::White } else { Color::White })
+                    .bg(if self.ac { Color::Green } else { Color::Black })
+                    .bold(),
+            )
+            .centered()
+            .render(flags_layout_split[1].inner(Margin::new(1, 0)), buf);
+        Paragraph::new("PSP")
+            .style(
+                Style::default()
+                    .fg(if self.psp { Color::White } else { Color::White })
+                    .bg(if self.psp { Color::Green } else { Color::Black })
+                    .bold(),
+            )
+            .centered()
+            .render(flags_layout_split[2].inner(Margin::new(1, 0)), buf);
+        Paragraph::new("RAD")
+            .style(
+                Style::default()
+                    .fg(if self.rad_fan {
+                        Color::White
+                    } else {
+                        Color::White
+                    })
+                    .bg(if self.rad_fan {
+                        Color::Green
+                    } else {
+                        Color::Black
+                    })
+                    .bold(),
+            )
+            .centered()
+            .render(flags_layout_split[3].inner(Margin::new(1, 0)), buf);
     }
 }

--- a/src/widgets/fuel_ignition.rs
+++ b/src/widgets/fuel_ignition.rs
@@ -19,7 +19,7 @@ impl FuelIgnitionBlock {
             inj_pw: ctx.injector_pulse_width_cyl_1,
             fuel_cut: ctx.fuel_cut,
             ignition_advance: ctx.ignition_advance,
-            fuel_used: ctx.cumulative_fuel,
+            fuel_used: ctx.total_fuel_used,
             fuel_flow_rate: ctx.fuel_flow_rate,
         }
     }

--- a/src/widgets/fuel_ignition.rs
+++ b/src/widgets/fuel_ignition.rs
@@ -10,6 +10,7 @@ pub struct FuelIgnitionBlock {
     fuel_cut: bool,
     ignition_advance: i8,
     fuel_used: f64,
+    fuel_flow_rate: f64,
 }
 
 impl FuelIgnitionBlock {
@@ -19,6 +20,7 @@ impl FuelIgnitionBlock {
             fuel_cut: ctx.fuel_cut,
             ignition_advance: ctx.ignition_advance,
             fuel_used: ctx.cumulative_fuel,
+            fuel_flow_rate: ctx.fuel_flow_rate,
         }
     }
 }
@@ -49,7 +51,7 @@ impl Widget for FuelIgnitionBlock {
             .split(area.inner(Margin::new(1, 0)));
         let row_two = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
+            .constraints(vec![Constraint::Length(8), Constraint::Percentage(100)])
             .split(fuel_ignition_block_layout[2]);
         if self.fuel_cut {
             Gauge::default()
@@ -77,14 +79,17 @@ impl Widget for FuelIgnitionBlock {
                 ))
                 .render(fuel_ignition_block_layout[1], buf);
         }
-        Paragraph::new(format!("IGN ADV: {}", self.ignition_advance))
+        Paragraph::new(format!("ADV: {}", self.ignition_advance))
             .white()
             .bold()
             .render(row_two[0], buf);
-        Paragraph::new(format!("L/U: {:.1}", self.fuel_used))
-            .white()
-            .bold()
-            .centered()
-            .render(row_two[1], buf);
+        Paragraph::new(format!(
+            "{:.1} ({:.1})",
+            self.fuel_used, self.fuel_flow_rate
+        ))
+        .white()
+        .bold()
+        .centered()
+        .render(row_two[1], buf);
     }
 }

--- a/src/widgets/fuel_ignition.rs
+++ b/src/widgets/fuel_ignition.rs
@@ -1,6 +1,6 @@
 use ratatui::{
     prelude::*,
-    widgets::{Block, Borders, Gauge},
+    widgets::{Block, Borders, Gauge, Paragraph},
 };
 
 use crate::sdl::EngineContext;
@@ -9,6 +9,7 @@ pub struct FuelIgnitionBlock {
     inj_pw: f32,
     fuel_cut: bool,
     ignition_advance: i8,
+    fuel_used: f64,
 }
 
 impl FuelIgnitionBlock {
@@ -17,6 +18,7 @@ impl FuelIgnitionBlock {
             inj_pw: ctx.injector_pulse_width_cyl_1,
             fuel_cut: ctx.fuel_cut,
             ignition_advance: ctx.ignition_advance,
+            fuel_used: ctx.cumulative_fuel,
         }
     }
 }
@@ -41,10 +43,14 @@ impl Widget for FuelIgnitionBlock {
             .constraints(vec![
                 Constraint::Length(1), // block header
                 Constraint::Length(3), // inj pw
-                Constraint::Length(1), // ign adv
+                Constraint::Length(1), // ign adv + fuel used
                 Constraint::Length(1), // block footer
             ])
             .split(area.inner(Margin::new(1, 0)));
+        let row_two = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(fuel_ignition_block_layout[2]);
         if self.fuel_cut {
             Gauge::default()
                 .percent(100)
@@ -71,12 +77,14 @@ impl Widget for FuelIgnitionBlock {
                 ))
                 .render(fuel_ignition_block_layout[1], buf);
         }
-        Span::styled(
-            format!("IGN ADV: {}", self.ignition_advance),
-            Style::default()
-                .fg(Color::White)
-                .add_modifier(Modifier::BOLD),
-        )
-        .render(fuel_ignition_block_layout[2], buf);
+        Paragraph::new(format!("IGN ADV: {}", self.ignition_advance))
+            .white()
+            .bold()
+            .render(row_two[0], buf);
+        Paragraph::new(format!("L/U: {:.1}", self.fuel_used))
+            .white()
+            .bold()
+            .centered()
+            .render(row_two[1], buf);
     }
 }

--- a/src/widgets/vehicle.rs
+++ b/src/widgets/vehicle.rs
@@ -7,12 +7,14 @@ use crate::sdl::EngineContext;
 
 pub struct VehicleBlock {
     speed: u8,
+    instant_consumption: f32,
 }
 
 impl VehicleBlock {
     pub fn new(ctx: &EngineContext) -> Self {
         Self {
             speed: ctx.vehicle_speed,
+            instant_consumption: ctx.instant_consumption,
         }
     }
 }
@@ -40,6 +42,10 @@ impl Widget for VehicleBlock {
                 Constraint::Length(1),
             ])
             .split(area.inner(Margin::new(1, 0)));
+        let row = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(speed_block[1]);
         let speed_color = match self.speed {
             speed if speed < 60 => (Color::Black, Color::White),
             speed if speed <= 80 => (Color::Black, Color::Green),
@@ -47,12 +53,17 @@ impl Widget for VehicleBlock {
             _ => (Color::Red, Color::White),
         };
         let speed = Span::styled(
-            format!("Speed: {} km/h", self.speed),
+            format!("{} km/h", self.speed),
             Style::default()
                 .bg(speed_color.0)
                 .fg(speed_color.1)
                 .add_modifier(Modifier::BOLD),
         );
-        speed.render(speed_block[1], buf);
+        let instant_consumption = Span::styled(
+            format!("{:.1} L/100km", self.instant_consumption),
+            Style::default().add_modifier(Modifier::BOLD),
+        );
+        speed.render(row[0], buf);
+        instant_consumption.render(row[1], buf);
     }
 }


### PR DESCRIPTION
- Resize status flags block to 1 content row. It looks really nice on desktop. Should be good on stereo too. No "ON/OFF" text now, just the identifier's background gets green
- Add calculations for instant fuel consumption, distance travelled, fuel used and long term fuel consumption (yet to verify)
- Store distance travelled and fuel used in file. on boot use file if present to continue fuel/distance from last saved state
- Reset trip meter by changing EL state 6 times under 8 seconds 

have yet to test stuff in car